### PR TITLE
Call .rotate() function before running resize

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,7 @@ var index = (function (options) {
                 width = option.width;
             }
             var promise = sharp__default['default'](file.contents, option.sharp !== undefined && option.sharp !== null && typeof option.sharp === "object" ? option.sharp : {})
+                .rotate()
                 .resize(width)
                 // @ts-ignore FormatEnum from Sharp does not accepts strings, but documentation shows it accepts...
                 .toFormat(format);

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ export default (options: IOptions): Transform => {
 			}
 
 			let promise = sharp(file.contents, option.sharp !== undefined && option.sharp !== null && typeof option.sharp === "object" ? option.sharp : {})
+				.rotate()
 				.resize(width)
 				// @ts-ignore FormatEnum from Sharp does not accepts strings, but documentation shows it accepts...
 				.toFormat(format);


### PR DESCRIPTION
Fixes portrait images with metadata being rotated to the wrong orientation.

Fixes issue https://github.com/khalyomede/gulp-sharp-responsive/issues/10